### PR TITLE
Fix Incorrect Month Display When Navigating Calendar

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -168,7 +168,11 @@ class Calendar {
     }
 
     changeMonth = (direction) => {
+        const originalDate = this.currentDate.getDate();
+        this.currentDate.setDate(1);
         this.currentDate.setMonth(this.currentDate.getMonth() + direction);
+        const maxDayInNewMonth = new Date(this.currentDate.getFullYear(), this.currentDate.getMonth() + 1, 0).getDate();
+        this.currentDate.setDate(Math.min(originalDate, maxDayInNewMonth));
         this.updateCalendar();
     }
 }


### PR DESCRIPTION
Resolved an issue where navigating to a previous month using the arrow button resulted in an incorrect month display. The problem arose due to the "roll over" behavior of the JavaScript 'Date' object when transitioning from months with more days (e.g., 31st of October) to months with fewer days (e.g., September, which only has 30 days). The fix ensures that the date is first set to the beginning of the month before changing the month and then adjusts accordingly to prevent rolling over to the next month.